### PR TITLE
ssl.wrap_socket deprecation fix

### DIFF
--- a/LdapRelayScan.py
+++ b/LdapRelayScan.py
@@ -118,10 +118,12 @@ def InternalDomainFromAnonymousLdap(nameserverIp):
 #no error at all. Any other "successful" edge cases
 #not yet accounted for.
 def DoesLdapsCompleteHandshake(dcIp):
+  context = ssl.create_default_context()
+  context.verify_mode = ssl.CERT_OPTIONAL
   s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-  s.settimeout(5)
-  ssl_sock = ssl.wrap_socket(s,
-                            cert_reqs=ssl.CERT_OPTIONAL,
+  context.check_hostname = False
+  s.settimeout(50)
+  ssl_sock = context.wrap_socket(s, server_side=False,
                             suppress_ragged_eofs=False,
                             do_handshake_on_connect=False)
   ssl_sock.connect((dcIp, 636))


### PR DESCRIPTION
Minimum necessary code to migrate for ISSUE #9 - ssl.wrap_socket() is deprecated.

This just implements the SSLContext.wrap_socket function as recommended in the Python spec:

> Deprecated since version 3.7: Since Python 3.2 and 2.7.9, it is recommended to use the [SSLContext.wrap_socket()](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.wrap_socket) instead of [wrap_socket()](https://docs.python.org/3/library/ssl.html#ssl.wrap_socket). The top-level function is limited and creates an insecure client socket without server name indication or hostname matching.

(Source: https://docs.python.org/3/library/ssl.html)

Example of the deprecation warning:
```
(venv) PS C:\Users\taborlin\Desktop\LdapRelayScan-main> python .\LdapRelayScan.py -dc-ip 10.0.0.10 -u "taborlin" -p "password lol"

~Domain Controllers identified~
   university.temerant.local

~Checking DCs for LDAP NTLM relay protections~
   university.temerant.local
C:\Users\taborlin\Desktop\LdapRelayScan-main\LdapRelayScan.py:123: DeprecationWarning: ssl.wrap_socket() is deprecated, use SSLContext.wrap_socket()
  ssl_sock = ssl.wrap_socket(s,
      [+] (LDAPS) CHANNEL BINDING SET TO "NEVER"! PARTY TIME!
```